### PR TITLE
fix: resolve Vercel build failure due to missing ESLint react-hooks config

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-26T23:57:17.354Z for PR creation at branch issue-1-5a7846a5a014 for issue https://github.com/MixaByk1996/elements-app/issues/1

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-26T23:57:17.354Z for PR creation at branch issue-1-5a7846a5a014 for issue https://github.com/MixaByk1996/elements-app/issues/1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,5 +18,8 @@
     "production": [">0.2%", "not dead", "not op_mini all"],
     "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
-  "proxy": "http://localhost:3001"
+  "proxy": "http://localhost:3001",
+  "eslintConfig": {
+    "extends": ["react-app"]
+  }
 }


### PR DESCRIPTION
## Problem

The Vercel deployment was failing with:

```
Failed to compile.
[eslint]
src/LeftPanel.js
  Line 24:3:  Definition for rule 'react-hooks/exhaustive-deps' was not found
  Line 31:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found
  Line 37:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found
src/RightPanel.js
  Line 70:3:  Definition for rule 'react-hooks/exhaustive-deps' was not found
  Line 76:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found
  Line 82:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found
```

## Root Cause

`LeftPanel.js` and `RightPanel.js` use `// eslint-disable-next-line react-hooks/exhaustive-deps` comments, which reference a rule from `eslint-plugin-react-hooks`. While this plugin is bundled inside `react-scripts`, it is only activated when the ESLint config explicitly extends `react-app`. Without an `eslintConfig` section in `package.json`, ESLint has no config and treats the rule as unknown — causing the build to fail with exit code 1.

## Fix

Added `"eslintConfig": { "extends": ["react-app"] }` to `frontend/package.json`. This is the standard Create React App configuration that activates all CRA-bundled plugins including `eslint-plugin-react-hooks`, making the `react-hooks/exhaustive-deps` rule available.

## Changes

- `frontend/package.json`: added `eslintConfig` field extending `react-app`

Fixes #1