### PR TITLE
fix: add eslint-plugin-react-hooks to fix Vercel build failure

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-29T06:26:21.923Z for PR creation at branch issue-8-d7f070ad1e80 for issue https://github.com/MixaByk1996/elements-app/issues/8

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-29T06:26:21.923Z for PR creation at branch issue-8-d7f070ad1e80 for issue https://github.com/MixaByk1996/elements-app/issues/8

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,9 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1"
+      },
+      "devDependencies": {
+        "eslint-plugin-react-hooks": "^4.6.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -15453,22 +15456,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,16 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"
   },
+  "devDependencies": {
+    "eslint-plugin-react-hooks": "^4.6.2"
+  },
+  "eslintConfig": {
+    "extends": ["react-app"],
+    "plugins": ["react-hooks"],
+    "rules": {
+      "react-hooks/exhaustive-deps": "warn"
+    }
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "CI=false DISABLE_ESLINT_PLUGIN=true react-scripts build"


### PR DESCRIPTION
## Summary

Fixes MixaByk1996/elements-app#8

The Vercel production build was failing with:
```
[eslint]
src/LeftPanel.js
  Line 24:3:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps
  Line 31:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps
  Line 37:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps

src/RightPanel.js
  Line 70:3:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps
  Line 76:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps
  Line 82:5:  Definition for rule 'react-hooks/exhaustive-deps' was not found  react-hooks/exhaustive-deps
```

## Root Cause

`LeftPanel.js` and `RightPanel.js` use `// eslint-disable-next-line react-hooks/exhaustive-deps` inline comments, but the `eslint-plugin-react-hooks` package was not an explicit dependency. ESLint fails when a disable comment references a rule from a plugin that is not configured.

## Changes

- Added `eslint-plugin-react-hooks@^4.6.2` to `devDependencies` in `frontend/package.json`
- Added `eslintConfig` field to `frontend/package.json` that:
  - Extends `react-app` (the default CRA config)
  - Explicitly registers the `react-hooks` plugin
  - Sets `react-hooks/exhaustive-deps` to `warn` (matching the intent of the disable comments)

## Test Plan

- [x] `npm run build` passes locally
- [x] Build passes with `CI=true DISABLE_ESLINT_PLUGIN=false` (simulating Vercel environment)
- [x] ESLint disable comments in `LeftPanel.js` and `RightPanel.js` are now valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)