### PR TITLE
Fix double request on select and add duplicate notification

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-29T19:42:54.945Z for PR creation at branch issue-14-ddf0c9c6c9bd for issue https://github.com/MixaByk1996/elements-app/issues/14

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-29T19:42:54.945Z for PR creation at branch issue-14-ddf0c9c6c9bd for issue https://github.com/MixaByk1996/elements-app/issues/14

--- a/backend/server.js
+++ b/backend/server.js
@@ -87,15 +87,22 @@ app.post('/api/elements/select', (req, res) => {
     return res.status(400).json({ error: 'ids must be an array' });
   }
 
+  const added = [];
+  const duplicates = [];
   for (const id of ids) {
     const numId = Number(id);
-    if (!isNaN(numId) && !state.selectedIds.has(numId)) {
-      state.selectedIds.add(numId);
-      state.sortOrder.push(numId);
+    if (!isNaN(numId)) {
+      if (state.selectedIds.has(numId)) {
+        duplicates.push(numId);
+      } else {
+        state.selectedIds.add(numId);
+        state.sortOrder.push(numId);
+        added.push(numId);
+      }
     }
   }
 
-  res.json({ ok: true, selectedCount: state.selectedIds.size });
+  res.json({ ok: true, added, duplicates, selectedCount: state.selectedIds.size });
 });
 
 app.post('/api/elements/deselect', (req, res) => {

--- a/frontend/src/LeftPanel.js
+++ b/frontend/src/LeftPanel.js
@@ -50,10 +50,15 @@ export function LeftPanel({ onSelect, refreshRef }) {
 
   const handleSelect = (id) => {
     setItems(prev => prev.filter(item => item.id !== id));
-    queueSelect([id], () => {
+    queueSelect([id], (result) => {
+      if (result && result.duplicates && result.duplicates.includes(id)) {
+        setAddError(`Элемент #${id} уже выбран`);
+        refresh();
+        load(true, filter);
+        return;
+      }
       onSelect(id);
     });
-    onSelect(id);
   };
 
   const handleAddElement = () => {
@@ -63,7 +68,13 @@ export function LeftPanel({ onSelect, refreshRef }) {
       return;
     }
     setAddError('');
-    queueAdd([parsed], () => {
+    queueAdd([parsed], (result, requestedIds) => {
+      if (result && result.added && requestedIds) {
+        const notAdded = requestedIds.filter(id => !result.added.includes(id));
+        if (notAdded.includes(parsed)) {
+          setAddError(`Элемент #${parsed} уже существует`);
+        }
+      }
       refresh();
       load(true, filter);
     });

--- a/frontend/src/RightPanel.js
+++ b/frontend/src/RightPanel.js
@@ -116,7 +116,6 @@ export function RightPanel({ onDeselect, refreshRef }) {
   const handleDeselect = (id) => {
     queueDeselect([id], () => onDeselect(id));
     setItems(prev => prev.filter(item => item.id !== id));
-    onDeselect(id);
   };
 
   const activeItem = activeId != null ? items.find(i => i.id === activeId) : null;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -31,12 +31,14 @@ async function flushAddQueue() {
   const ids = Array.from(pendingAddIds);
   pendingAddIds = new Set();
 
+  let result = null;
   try {
-    await fetch(`${BASE_URL}/api/elements/add`, {
+    const res = await fetch(`${BASE_URL}/api/elements/add`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ids }),
     });
+    result = await res.json();
   } catch (e) {
     console.error('Failed to flush add queue:', e);
     ids.forEach(id => pendingAddIds.add(id));
@@ -45,7 +47,7 @@ async function flushAddQueue() {
   }
 
   const cbs = flushCallbacks.add.splice(0);
-  cbs.forEach(cb => cb());
+  cbs.forEach(cb => cb(result, ids));
 }
 
 async function flushReadQueue() {
@@ -61,14 +63,14 @@ async function flushReadQueue() {
 
   const promises = [];
 
+  let selectPromise = null;
   if (selectIds.length > 0) {
-    promises.push(
-      fetch(`${BASE_URL}/api/elements/select`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ids: selectIds }),
-      })
-    );
+    selectPromise = fetch(`${BASE_URL}/api/elements/select`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: selectIds }),
+    }).then(r => r.json());
+    promises.push(selectPromise);
   }
 
   if (deselectIds.length > 0) {
@@ -91,14 +93,18 @@ async function flushReadQueue() {
     );
   }
 
+  let selectResult = null;
   try {
     await Promise.all(promises);
+    if (selectPromise) {
+      selectResult = await selectPromise;
+    }
   } catch (e) {
     console.error('Failed to flush read/modify queue:', e);
   }
 
   const cbs = flushCallbacks.readModify.splice(0);
-  cbs.forEach(cb => cb());
+  cbs.forEach(cb => cb(selectResult));
 }
 
 export function queueAdd(ids, onFlushed) {


### PR DESCRIPTION
## Summary

Fixes MixaByk1996/elements-app#14

- **Fix double request**: `onSelect` callback in `LeftPanel` and `onDeselect` callback in `RightPanel` were called twice — once immediately and once inside the queue flush callback. This caused the opposite panel to refresh twice on each action. Removed the immediate duplicate call, keeping only the callback-based one.
- **Add duplicate notification**: When a user tries to select an already-selected element or add a custom element that already exists, a red error message is now displayed (e.g., "Элемент #1 уже выбран" / "Элемент #2000000 уже существует"). The backend `POST /api/elements/select` endpoint now returns `added` and `duplicates` arrays so the frontend can detect and report duplicates.

## Changes

| File | Change |
|------|--------|
| `frontend/src/LeftPanel.js` | Remove duplicate `onSelect()` call; add duplicate detection messages for select and add |
| `frontend/src/RightPanel.js` | Remove duplicate `onDeselect()` call |
| `frontend/src/api.js` | Parse API responses in `flushAddQueue` and `flushReadQueue`, pass result data to callbacks |
| `backend/server.js` | Return `added[]` and `duplicates[]` from `POST /api/elements/select` |

## Root Cause Analysis

**Double request bug**: In `LeftPanel.handleSelect`, `onSelect(id)` was called both inside the `queueSelect` callback (line 54) AND immediately after it (line 56). Since `onSelect` triggers `rightRefreshRef.current()` in `App.js`, this caused two separate refreshes of the right panel. The same pattern existed in `RightPanel.handleDeselect`.

**Missing duplicate message**: The backend silently ignored duplicates without returning any indication. The frontend had no way to know whether the operation was a duplicate or a success.

## Test Plan

- [x] Backend builds and starts successfully
- [x] Frontend compiles without errors
- [x] `POST /api/elements/select` with new ID returns `added: [id], duplicates: []`
- [x] `POST /api/elements/select` with existing ID returns `added: [], duplicates: [id]`
- [x] `POST /api/elements/add` with new custom ID returns `added: [id]`
- [x] `POST /api/elements/add` with existing custom ID returns `added: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)